### PR TITLE
[Feat] 도메인 및 데이터 베이스 구현

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEAT]"
+labels: enhancement
+assignees: ''
+
+---
+
+내용
+--
+- 냉무
+
+TODO
+--
+- [ ] Mercury
+- [x] Venus
+- [x] Earth (Orbit/Moon)
+
+보완사항
+--
+- 냉무

--- a/src/main/java/com/kuit/moamoa/domain/ChallengeCategory.java
+++ b/src/main/java/com/kuit/moamoa/domain/ChallengeCategory.java
@@ -1,0 +1,10 @@
+package com.kuit.moamoa.domain;
+
+public enum ChallengeCategory {
+    TAXI,        // 택시비
+    DELIVERY_FOOD,    // 배달음식
+    COFFEE,           // 커피
+    IMPULSE_BUY,      // 충동구매
+    DRINKING,         // 술자리
+    HOBBY             // 취미
+}

--- a/src/main/java/com/kuit/moamoa/domain/ChallengeRecord.java
+++ b/src/main/java/com/kuit/moamoa/domain/ChallengeRecord.java
@@ -1,2 +1,63 @@
-package com.kuit.moamoa.domain;public class ChallengeRecord {
+package com.kuit.moamoa.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)  // b/c reflection api
+@Getter
+@Table(name = "challenge_records")
+public class ChallengeRecord {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate endDate;
+
+    @Column(nullable = false)
+    private Long transaction;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    // 양방향 관계: 편의 메서드
+    public void setUser(User user) {
+        this.user = user;
+        if (!user.getChallengeRecords().contains(this)) {
+            user.getChallengeRecords().add(this);
+        }
+    }
 }

--- a/src/main/java/com/kuit/moamoa/domain/ChallengeRecord.java
+++ b/src/main/java/com/kuit/moamoa/domain/ChallengeRecord.java
@@ -26,6 +26,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 public class ChallengeRecord {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "challenge_record_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/kuit/moamoa/domain/ChallengeRecord.java
+++ b/src/main/java/com/kuit/moamoa/domain/ChallengeRecord.java
@@ -1,0 +1,2 @@
+package com.kuit.moamoa.domain;public class ChallengeRecord {
+}

--- a/src/main/java/com/kuit/moamoa/domain/Consumption.java
+++ b/src/main/java/com/kuit/moamoa/domain/Consumption.java
@@ -1,5 +1,6 @@
 package com.kuit.moamoa.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -26,14 +27,18 @@ public class Consumption {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Column(nullable = false)
     private Long amount;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private ConsumptionCategory consumptionCategory;
+
 
     @Enumerated(EnumType.STRING)
     private ChallengeCategory challengeCategory;

--- a/src/main/java/com/kuit/moamoa/domain/Consumption.java
+++ b/src/main/java/com/kuit/moamoa/domain/Consumption.java
@@ -1,0 +1,57 @@
+package com.kuit.moamoa.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)  // b/c reflection api
+@Getter
+@Table(name = "consumptions")
+public class Consumption {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private Long amount;
+
+    @Enumerated(EnumType.STRING)
+    private ConsumptionCategory consumptionCategory;
+
+    @Enumerated(EnumType.STRING)
+    private ChallengeCategory challengeCategory;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    // 양방향 관계: 편의 메서드
+    public void setUser(User user) {
+        this.user = user;
+        if (!user.getConsumptions().contains(this)) {
+            user.getConsumptions().add(this);
+        }
+    }
+}

--- a/src/main/java/com/kuit/moamoa/domain/Consumption.java
+++ b/src/main/java/com/kuit/moamoa/domain/Consumption.java
@@ -27,7 +27,6 @@ public class Consumption {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/com/kuit/moamoa/domain/Consumption.java
+++ b/src/main/java/com/kuit/moamoa/domain/Consumption.java
@@ -24,6 +24,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Table(name = "consumptions")
 public class Consumption {
     @Id
+    @Column(name = "consumption_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/main/java/com/kuit/moamoa/domain/ConsumptionCategory.java
+++ b/src/main/java/com/kuit/moamoa/domain/ConsumptionCategory.java
@@ -1,0 +1,10 @@
+package com.kuit.moamoa.domain;
+
+public enum ConsumptionCategory {
+    FIXED,       // 고정비
+    BEAUTY,      // 꾸밈비
+    ACTIVITY,    // 활동비
+    LIVING,      // 생활비
+    CELEBRATION, // 기여비
+    ETC
+}

--- a/src/main/java/com/kuit/moamoa/domain/Friendship.java
+++ b/src/main/java/com/kuit/moamoa/domain/Friendship.java
@@ -1,0 +1,2 @@
+package com.kuit.moamoa.domain;public class Friendship {
+}

--- a/src/main/java/com/kuit/moamoa/domain/Friendship.java
+++ b/src/main/java/com/kuit/moamoa/domain/Friendship.java
@@ -1,2 +1,41 @@
-package com.kuit.moamoa.domain;public class Friendship {
+package com.kuit.moamoa.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "friendships")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Friendship {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long toUserId;
+
+    @Column(nullable = false)
+    private Long fromUserId;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
 }

--- a/src/main/java/com/kuit/moamoa/domain/Friendship.java
+++ b/src/main/java/com/kuit/moamoa/domain/Friendship.java
@@ -21,6 +21,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Friendship {
     @Id
+    @Column(name = "friendship_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/main/java/com/kuit/moamoa/domain/Status.java
+++ b/src/main/java/com/kuit/moamoa/domain/Status.java
@@ -1,0 +1,5 @@
+package com.kuit.moamoa.domain;
+
+public enum Status {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/com/kuit/moamoa/domain/User.java
+++ b/src/main/java/com/kuit/moamoa/domain/User.java
@@ -1,0 +1,30 @@
+package com.kuit.moamoa.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.List;
+import lombok.Getter;
+
+@Entity
+@Table(name = "users")
+@Getter
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToMany(mappedBy = "user")
+    private List<Consumption> consumptions;
+
+    // 양방향 관계: 편의 메서드
+    public void addConsumption(Consumption consumption) {
+        this.consumptions.add(consumption);
+        if (consumption.getUser() != this) {
+            consumption.setUser(this);
+        }
+    }
+}

--- a/src/main/java/com/kuit/moamoa/domain/User.java
+++ b/src/main/java/com/kuit/moamoa/domain/User.java
@@ -1,5 +1,6 @@
 package com.kuit.moamoa.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -14,6 +15,7 @@ import lombok.Getter;
 @Getter
 public class User {
     @Id
+    @Column(name = "user_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/main/java/com/kuit/moamoa/domain/User.java
+++ b/src/main/java/com/kuit/moamoa/domain/User.java
@@ -20,11 +20,22 @@ public class User {
     @OneToMany(mappedBy = "user")
     private List<Consumption> consumptions;
 
+    @OneToMany(mappedBy = "user")
+    private List<ChallengeRecord> challengeRecords;
+
     // 양방향 관계: 편의 메서드
     public void addConsumption(Consumption consumption) {
         this.consumptions.add(consumption);
         if (consumption.getUser() != this) {
             consumption.setUser(this);
+        }
+    }
+
+    // 양방향 관계: 편의 메서드
+    public void addChallengeRecords(ChallengeRecord challengeRecord) {
+        this.challengeRecords.add(challengeRecord);
+        if (challengeRecord.getUser() != this) {
+            challengeRecord.setUser(this);
         }
     }
 }


### PR DESCRIPTION
### ✏️ 작업 개요
아래 도메인들 구현 및 데이터 베이스 구축

### ⛳ 작업 분류
- [x] Consumption
- [x] Friendship
- [x] ChallengeRecords

### 🔨 작업 상세 내용
1. user-consumption 양방향 관계
2. user-challengeRecord 양방향 관계로 설정하고, 일단은 편의메서드는 두 도메인 모두에 생성하였습니다. 
3. 친구관계(friendship)가 join되서 query될 이유가 없을거 같아, user와 관계를 생성하지 않았습니다.
4. challengeRecord: 기존 duration에서 LocalDate 형식의 startDate, endDate 두개로 구현하였습니다. 

### 💡 생각해볼 문제
- relationship between friendship and user?
- ⭐ duration에서 시작날짜 끝나는 날짜를 표시할 방법이 없는거 같아, 위와 같이 수정 하였습니다. 
- package구조는 나중에 한번 손 봐야할거 같습니다. 