### PR TITLE
user, attendance, purchase_record 엔티티 설계 

### DIFF
--- a/src/main/java/com/kuit/moamoa/domain/Attendance.java
+++ b/src/main/java/com/kuit/moamoa/domain/Attendance.java
@@ -1,0 +1,34 @@
+package com.kuit.moamoa.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "attendance")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Attendance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+}

--- a/src/main/java/com/kuit/moamoa/domain/Attendance.java
+++ b/src/main/java/com/kuit/moamoa/domain/Attendance.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -12,11 +13,12 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "attendance")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
+@Getter @Setter
 public class Attendance {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "attendance_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -31,4 +33,5 @@ public class Attendance {
 
     @Enumerated(EnumType.STRING)
     private Status status;
+
 }

--- a/src/main/java/com/kuit/moamoa/domain/Item.java
+++ b/src/main/java/com/kuit/moamoa/domain/Item.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "item")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
+@Getter @Setter
 public class Item {
     // 화면설계서에서 기준 구매 가능 아이템이 '프로필 테두리'밖에 보이지 않아서 id, name만 만들었습니다
 
@@ -23,6 +24,9 @@ public class Item {
     @Column(nullable = false)
     private String name;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    private PurchaseRecord purchaseRecord = new PurchaseRecord();
+
     @CreationTimestamp
     private LocalDateTime createdAt;
 
@@ -31,4 +35,5 @@ public class Item {
 
     @Enumerated(EnumType.STRING)
     private Status status;
+
 }

--- a/src/main/java/com/kuit/moamoa/domain/Item.java
+++ b/src/main/java/com/kuit/moamoa/domain/Item.java
@@ -1,0 +1,34 @@
+package com.kuit.moamoa.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "item")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Item {
+    // 화면설계서에서 기준 구매 가능 아이템이 '프로필 테두리'밖에 보이지 않아서 id, name만 만들었습니다
+
+    @Id
+    @GeneratedValue(strategy =GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+}

--- a/src/main/java/com/kuit/moamoa/domain/PurchaseRecord.java
+++ b/src/main/java/com/kuit/moamoa/domain/PurchaseRecord.java
@@ -40,11 +40,6 @@ public class PurchaseRecord {
     @Enumerated(EnumType.STRING)
     private Status status;
 
-    public void setUser(User user){
-        this.user=user;
-        user.getPurchaseRecords().add(this);
-    }
-
     public void setItem(Item item){
         this.item=item;
         item.setPurchaseRecord(this);

--- a/src/main/java/com/kuit/moamoa/domain/PurchaseRecord.java
+++ b/src/main/java/com/kuit/moamoa/domain/PurchaseRecord.java
@@ -17,13 +17,14 @@ public class PurchaseRecord {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "purchase_record_id")
     private Long id;
 
     @OneToOne
     @JoinColumn(name = "item_id")
     private Item item;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
 
@@ -38,4 +39,14 @@ public class PurchaseRecord {
 
     @Enumerated(EnumType.STRING)
     private Status status;
+
+    public void setUser(User user){
+        this.user=user;
+        user.getPurchaseRecords().add(this);
+    }
+
+    public void setItem(Item item){
+        this.item=item;
+        item.setPurchaseRecord(this);
+    }
 }

--- a/src/main/java/com/kuit/moamoa/domain/PurchaseRecord.java
+++ b/src/main/java/com/kuit/moamoa/domain/PurchaseRecord.java
@@ -20,11 +20,11 @@ public class PurchaseRecord {
     @Column(name = "purchase_record_id")
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_id")
     private Item item;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/kuit/moamoa/domain/PurchaseRecord.java
+++ b/src/main/java/com/kuit/moamoa/domain/PurchaseRecord.java
@@ -1,0 +1,41 @@
+package com.kuit.moamoa.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "purchase_record")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class PurchaseRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "item_id")
+    private Item item;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private int transaction;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+}

--- a/src/main/java/com/kuit/moamoa/domain/Status.java
+++ b/src/main/java/com/kuit/moamoa/domain/Status.java
@@ -1,0 +1,5 @@
+package com.kuit.moamoa.domain;
+
+public enum Status {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/com/kuit/moamoa/domain/User.java
+++ b/src/main/java/com/kuit/moamoa/domain/User.java
@@ -1,0 +1,49 @@
+package com.kuit.moamoa.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String login_id;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column
+    @Lob
+    private String profile_image; // 확인 필요: db에서 이미지를 어떤 방식으로 저장하는지
+
+    @Column(nullable = false)
+    private int level;
+
+    @Column(nullable = false)
+    private int coin;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+}

--- a/src/main/java/com/kuit/moamoa/domain/User.java
+++ b/src/main/java/com/kuit/moamoa/domain/User.java
@@ -4,10 +4,13 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "user")
@@ -17,6 +20,7 @@ public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long id;
 
     @Column(nullable = false)
@@ -38,6 +42,12 @@ public class User {
     @Column(nullable = false)
     private int coin;
 
+    @OneToMany(mappedBy = "user")
+    private List<PurchaseRecord> purchaseRecords = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Attendance> attendances = new ArrayList<>();
+
     @CreationTimestamp
     private LocalDateTime createdAt;
 
@@ -46,4 +56,14 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     private Status status;
+
+    public void addAttendances(Attendance attendance){
+        attendances.add(attendance);
+        attendance.setUser(this);
+    }
+
+    public void addPurchaseRecords(PurchaseRecord purchaseRecord){
+        purchaseRecords.add(purchaseRecord);
+        purchaseRecord.setUser(this);
+    }
 }


### PR DESCRIPTION
### ✏️ 작업 개요
아래 도메인 설계

### ⛳ 작업 분류
- [x] User
- [x] Attendance
- [x] Purchase_record

### 🔨 작업 상세 내용
1. User쪽에서 addAttendances와 addPurchaseRecords 편의 메서드를 구현하였습니다.
2. Attendance에서는 따로 편의 메서드가 없고 PurchaseRecord에선 setItem이 존재합니다.

### 💡 생각해볼 문제
- Attendance, Item, PurchaseRecord에 @Setter가 생겼는데 괜찮을까요?
- User의 profile_image를 어떻게 db에 넣어야할 지 고민입니다.
- 각 엔티티의 id 컬럼명을 '클래스명_id' 로 지정하는건 어떨까요